### PR TITLE
fix: correct API base URL formatting in fetchUserStats function

### DIFF
--- a/nyt-crossword-frontend/src/services/FetchData.tsx
+++ b/nyt-crossword-frontend/src/services/FetchData.tsx
@@ -9,7 +9,7 @@ const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:808
  */
 export const fetchUserStats = async (userID: string) => {
     try {
-        const response = await axios.get(`${API_BASE_URL}/api/users/stats/${userID}`);
+        const response = await axios.get(`${API_BASE_URL}api/users/stats/${userID}`);
         return response.data; // Return the stats data from the response
     } catch (error) {
         console.error(`Error fetching user stats for userID ${userID}:`, error);


### PR DESCRIPTION
- Removed the trailing slash from the API_BASE_URL in the axios GET request to ensure proper URL construction for fetching user statistics.